### PR TITLE
Adjust xz constraints

### DIFF
--- a/xz/FeatureModel.xml
+++ b/xz/FeatureModel.xml
@@ -2040,7 +2040,7 @@
   </numericOptions>
   <booleanConstraints>
     <constraint>!Stdout  |  TestDecompr</constraint>
-    <constraint>AuxiliaryFeatures =&gt; NoPreset | NoDict | NoLc | NoLp | NoPb | NoNice | NoDepth | NoStart | NoDist | NoThreads | NoBytesCompr | NoPercentCompr | NoSize | NoFlushTO | NoBytesDecompr | NoPercentDecompr</constraint>
+    <constraint>AuxiliaryFeatures | !NoPreset &amp; !NoDict &amp; !NoLc &amp; !NoLp &amp; !NoPb &amp; !NoNice &amp; !NoDepth &amp; !NoStart &amp; !NoDist &amp; !NoThreads &amp; !NoBytesCompr &amp; !NoPercentCompr &amp; !NoSize &amp; !NoFlushTO &amp; !NoBytesDecompr &amp; !NoPercentDecompr</constraint>
     <constraint>Preset | NoPreset</constraint>
     <constraint>!Preset | !NoPreset</constraint>
     <constraint>dict | NoDict</constraint>
@@ -2073,13 +2073,13 @@
     <constraint>!BytesDecompr | !NoBytesDecompr</constraint>
     <constraint>PercentDecompr | NoPercentDecompr</constraint>
     <constraint>!PercentDecompr | !NoPercentDecompr</constraint>
-    <constraint>Blocks =&gt; xz</constraint>
-    <constraint>lzma =&gt; LZMA1</constraint>
-    <constraint>xz =&gt; !LZMA1</constraint>
-    <constraint>FlushTO =&gt; LZMA2 | Delta</constraint>
-    <constraint>Test =&gt; KeepIn</constraint>
-    <constraint>TestDecompr =&gt; Test | Decompr</constraint>
-    <constraint>Memory =&gt; MaxMemCompr | MaxMemDecompr</constraint>
+    <constraint>Blocks | !xz</constraint>
+    <constraint>lzma | !LZMA1</constraint>
+    <constraint>xz | LZMA1</constraint>
+    <constraint>FlushTO | !LZMA2 &amp; !Delta</constraint>
+    <constraint>Test | !KeepIn</constraint>
+    <constraint>TestDecompr | !Test &amp; !Decompr</constraint>
+    <constraint>Memory | !MaxMemCompr &amp; !MaxMemDecompr</constraint>
   </booleanConstraints>
   <nonBooleanConstraints />
   <mixedConstraints>

--- a/xz/FeatureModel.xml
+++ b/xz/FeatureModel.xml
@@ -2040,7 +2040,7 @@
   </numericOptions>
   <booleanConstraints>
     <constraint>!Stdout  |  TestDecompr</constraint>
-    <constraint>AuxiliaryFeatures | !NoPreset &amp; !NoDict &amp; !NoLc &amp; !NoLp &amp; !NoPb &amp; !NoNice &amp; !NoDepth &amp; !NoStart &amp; !NoDist &amp; !NoThreads &amp; !NoBytesCompr &amp; !NoPercentCompr &amp; !NoSize &amp; !NoFlushTO &amp; !NoBytesDecompr &amp; !NoPercentDecompr</constraint>
+    <constraint>!AuxiliaryFeatures | NoPreset | NoDict | NoLc | NoLp | NoPb | NoNice | NoDepth | NoStart | NoDist | NoThreads | NoBytesCompr | NoPercentCompr | NoSize | NoFlushTO | NoBytesDecompr | NoPercentDecompr</constraint>
     <constraint>Preset | NoPreset</constraint>
     <constraint>!Preset | !NoPreset</constraint>
     <constraint>dict | NoDict</constraint>
@@ -2073,13 +2073,13 @@
     <constraint>!BytesDecompr | !NoBytesDecompr</constraint>
     <constraint>PercentDecompr | NoPercentDecompr</constraint>
     <constraint>!PercentDecompr | !NoPercentDecompr</constraint>
-    <constraint>Blocks | !xz</constraint>
-    <constraint>lzma | !LZMA1</constraint>
-    <constraint>xz | LZMA1</constraint>
-    <constraint>FlushTO | !LZMA2 &amp; !Delta</constraint>
-    <constraint>Test | !KeepIn</constraint>
-    <constraint>TestDecompr | !Test &amp; !Decompr</constraint>
-    <constraint>Memory | !MaxMemCompr &amp; !MaxMemDecompr</constraint>
+    <constraint>!Blocks | xz</constraint>
+    <constraint>!lzma | LZMA1</constraint>
+    <constraint>!xz | !LZMA1</constraint>
+    <constraint>!FlushTO | LZMA2 | Delta</constraint>
+    <constraint>!Test | KeepIn</constraint>
+    <constraint>!TestDecompr | Test | Decompr</constraint>
+    <constraint>!Memory | MaxMemCompr | MaxMemDecompr</constraint>
   </booleanConstraints>
   <nonBooleanConstraints />
   <mixedConstraints>


### PR DESCRIPTION
The constraints in XZ had to be readjusted since we (or at least SPL Conqueror) support only boolean operators in boolean constraints.